### PR TITLE
[Design] 핀 추가 뷰 추가

### DIFF
--- a/Re-Nav.xcodeproj/project.pbxproj
+++ b/Re-Nav.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2600D1212B065A8400B52CF4 /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600D1202B065A8400B52CF4 /* SettingView.swift */; };
 		2600D1232B065A9000B52CF4 /* PinListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600D1222B065A9000B52CF4 /* PinListView.swift */; };
 		2600D1262B0661CF00B52CF4 /* KakaoMapsSDK_SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 2600D1252B0661CF00B52CF4 /* KakaoMapsSDK_SPM */; };
+		2600D1292B06BA6900B52CF4 /* PinCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2600D1282B06BA6900B52CF4 /* PinCreationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,7 @@
 		2600D1202B065A8400B52CF4 /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		2600D1222B065A9000B52CF4 /* PinListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinListView.swift; sourceTree = "<group>"; };
 		2600D1272B0679F900B52CF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		2600D1282B06BA6900B52CF4 /* PinCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinCreationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +66,7 @@
 				2600D1102B06533B00B52CF4 /* Re_NavApp.swift */,
 				2600D1122B06533C00B52CF4 /* ContentView.swift */,
 				2600D11E2B065A7100B52CF4 /* MapView.swift */,
+				2600D1282B06BA6900B52CF4 /* PinCreationView.swift */,
 				2600D1202B065A8400B52CF4 /* SettingView.swift */,
 				2600D1222B065A9000B52CF4 /* PinListView.swift */,
 				2600D1142B06533D00B52CF4 /* Assets.xcassets */,
@@ -157,6 +160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2600D1232B065A9000B52CF4 /* PinListView.swift in Sources */,
+				2600D1292B06BA6900B52CF4 /* PinCreationView.swift in Sources */,
 				2600D1132B06533C00B52CF4 /* ContentView.swift in Sources */,
 				2600D1212B065A8400B52CF4 /* SettingView.swift in Sources */,
 				2600D11F2B065A7100B52CF4 /* MapView.swift in Sources */,

--- a/Re-Nav/PinCreationView.swift
+++ b/Re-Nav/PinCreationView.swift
@@ -1,0 +1,24 @@
+//
+//  PinCreationView.swift
+//  Re-Nav
+//
+//  Created by 김민택 on 11/17/23.
+//
+
+import SwiftUI
+
+struct PinCreationView: View {
+    var body: some View {
+        NavigationStack {
+            VStack {
+            }
+            .navigationTitle("핀 추가")
+            .navigationBarTitleDisplayMode(.inline)
+            .padding(16)
+        }
+    }
+}
+
+#Preview {
+    PinCreationView()
+}

--- a/Re-Nav/PinCreationView.swift
+++ b/Re-Nav/PinCreationView.swift
@@ -11,6 +11,15 @@ struct PinCreationView: View {
     var body: some View {
         NavigationStack {
             VStack {
+                Button(action: {}, label: {
+                    Text("확인")
+                        .foregroundStyle(.white)
+                        .background {
+                            RoundedRectangle(cornerRadius: 16)
+                                .frame(width: UIScreen.main.bounds.width-32, height: 50)
+                                .foregroundStyle(.red)
+                        }
+                })
             }
             .navigationTitle("핀 추가")
             .navigationBarTitleDisplayMode(.inline)

--- a/Re-Nav/PinCreationView.swift
+++ b/Re-Nav/PinCreationView.swift
@@ -11,6 +11,7 @@ struct PinCreationView: View {
     @State private var name = ""
     @State private var address = ""
     @State private var detail = ""
+    @State private var starRate = 1
 
     var body: some View {
         NavigationStack {
@@ -96,7 +97,7 @@ struct PinCreationView: View {
                     .padding(.top, 8)
 
                     HStack {
-                        // StarShape Rating
+                        RatingView(rate: $starRate)
                     }
                     .padding(.bottom, 8)
                 }
@@ -115,6 +116,38 @@ struct PinCreationView: View {
             .navigationBarTitleDisplayMode(.inline)
             .padding(16)
         }
+    }
+}
+
+struct RatingView: View {
+    @Binding var rate: Int
+    var maxRate = 5
+    var inActiveSymbol: Image?
+    var activeSymbol = Image(systemName: "star.fill")
+    var inActiveColor = Color.gray
+    var activeColor = Color.yellow
+    var size = (UIScreen.main.bounds.width-70) / 5
+
+    var body: some View {
+        HStack {
+            ForEach(1...maxRate, id: \.self) { idx in
+                symbol(for: idx)
+                    .resizable()
+                    .frame(width: size, height: size)
+                    .foregroundStyle(idx > rate ? inActiveColor : activeColor)
+                    .onTapGesture {
+                        rate = idx
+                    }
+            }
+        }
+    }
+
+    private func symbol(for number: Int) -> Image {
+        if number > rate {
+            return inActiveSymbol ?? activeSymbol
+        }
+
+        return activeSymbol
     }
 }
 

--- a/Re-Nav/PinCreationView.swift
+++ b/Re-Nav/PinCreationView.swift
@@ -19,6 +19,7 @@ struct PinCreationView: View {
                 ScrollView {
                     HStack {
                         Text("테마")
+                            .fontWeight(.bold)
                         Spacer()
                         Button(action: {}, label: {
                             Text("음식")
@@ -32,6 +33,7 @@ struct PinCreationView: View {
 
                     HStack {
                         Text("상호")
+                            .fontWeight(.bold)
                             .padding(.trailing)
 
                         VStack {
@@ -45,6 +47,7 @@ struct PinCreationView: View {
 
                     HStack {
                         Text("주소")
+                            .fontWeight(.bold)
                             .padding(.trailing)
 
                         VStack {
@@ -58,6 +61,7 @@ struct PinCreationView: View {
 
                     HStack {
                         Text("사진")
+                            .fontWeight(.bold)
                         Spacer()
                     }
                     .padding(.top, 8)
@@ -81,6 +85,7 @@ struct PinCreationView: View {
 
                     HStack {
                         Text("설명")
+                            .fontWeight(.bold)
                         Spacer()
                     }
                     .padding(.top, 8)
@@ -92,6 +97,7 @@ struct PinCreationView: View {
 
                     HStack {
                         Text("평점")
+                            .fontWeight(.bold)
                         Spacer()
                     }
                     .padding(.top, 8)

--- a/Re-Nav/PinCreationView.swift
+++ b/Re-Nav/PinCreationView.swift
@@ -8,9 +8,99 @@
 import SwiftUI
 
 struct PinCreationView: View {
+    @State private var name = ""
+    @State private var address = ""
+    @State private var detail = ""
+
     var body: some View {
         NavigationStack {
             VStack {
+                ScrollView {
+                    HStack {
+                        Text("테마")
+                        Spacer()
+                        Button(action: {}, label: {
+                            Text("음식")
+                        })
+                        .buttonStyle(.borderedProminent)
+                        .tint(.gray)
+                        .buttonBorderShape(.roundedRectangle(radius: 16))
+                        .foregroundStyle(.black)
+                    }
+                    .padding(.vertical, 8)
+
+                    HStack {
+                        Text("상호")
+                            .padding(.trailing)
+
+                        VStack {
+                            TextField("상호명을 입력하세요", text: $name)
+                            Rectangle()
+                                .frame(height: 1)
+                                .foregroundStyle(.gray)
+                        }
+                    }
+                    .padding(.vertical, 8)
+
+                    HStack {
+                        Text("주소")
+                            .padding(.trailing)
+
+                        VStack {
+                            TextField("주소를 입력하세요", text: $address)
+                            Rectangle()
+                                .frame(height: 1)
+                                .foregroundStyle(.gray)
+                        }
+                    }
+                    .padding(.vertical, 8)
+
+                    HStack {
+                        Text("사진")
+                        Spacer()
+                    }
+                    .padding(.top, 8)
+
+                    ScrollView(.horizontal) {
+                        HStack {
+                            Button(action: {}, label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .frame(width: 100, height: 100)
+                                        .foregroundStyle(.gray)
+                                    Image(systemName: "plus.circle.fill")
+                                        .resizable()
+                                        .frame(width: 25, height: 25)
+                                        .foregroundStyle(.red)
+                                }
+                            })
+                        }
+                    }
+                    .padding(.bottom, 8)
+
+                    HStack {
+                        Text("설명")
+                        Spacer()
+                    }
+                    .padding(.top, 8)
+
+                    TextField("설명을 입력하세요", text: $detail, axis: .vertical)
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(5, reservesSpace: true)
+                        .padding(.bottom, 8)
+
+                    HStack {
+                        Text("평점")
+                        Spacer()
+                    }
+                    .padding(.top, 8)
+
+                    HStack {
+                        // StarShape Rating
+                    }
+                    .padding(.bottom, 8)
+                }
+
                 Button(action: {}, label: {
                     Text("확인")
                         .foregroundStyle(.white)


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 핀 추가를 위한 상세정보를 입력할 뷰의 레이아웃을 구성하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 핀 추가 뷰 레이아웃 추가
- 평점을 위한 RatingView 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)
| 피그마 디자인 | 실제 레이아웃 |
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/81027256/283593215-a6fb5cbf-2353-4258-9af8-337de19821d0.png">|<img src="https://github.com/taek0622/Re-Nav/assets/81027256/0ee32ce2-ca46-449e-8899-d5dcf5b88301" width="265">|

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- TextField의 높이를 늘리는 방법 [Apple Developer SwiftUI 공식 문서 - lineLimit(_:reservesSpace:)](https://developer.apple.com/documentation/swiftui/view/linelimit(_:reservesspace:))

## Close Issues 🔒 (닫을 Issue)
Close #5.
